### PR TITLE
docs: Add README landing page for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# OctoAcme Project Management Docs — README
+
+## Project Management Process Summary
+
+OctoAcme’s project management framework ensures repeatable, customer-focused delivery across cross-functional teams. These living documents centralize team knowledge, accelerate onboarding, and equip members to collaborate and improve processes together.
+
+### Purpose
+
+- Centralize process guidance so teams can onboard faster and execute more consistently.
+- Document decision rationale and process improvements so everyone stays informed.
+- Connect this repository as a structured knowledge source for workflows and standards.
+
+### Principles
+
+- Customer-first: prioritize outcomes and usability in every phase.
+- Iterative delivery: ship frequent, testable increments for faster learning.
+- Clear ownership: named responsibles for project execution and outcomes (see Roles).
+- Data-driven decisions: measure impact, analyze experiments, and evolve processes.
+- Psychological safety: encourage transparent conversation about risks, trade-offs, and improvements.
+
+### Project Lifecycle
+
+1. Initiation — Validate the problem, align stakeholders, outline success metrics.
+2. Planning — Define scope, resources, milestones, risks, and actionable tasks.
+3. Execution — Build, test, track progress, and escalate blockers using team-defined rhythms.
+4. Release & Deployment — Standardize delivery to production, verify results, communicate updates.
+5. Retrospective & Continuous Improvement — Capture learnings, prioritize improvements, and reinforce an iterative culture.
+
+### Core Roles
+
+- Project Manager: Coordinates schedules, risks, communications, and documentation.
+- Product Manager: Defines outcomes, manages backlog, and drives prioritization.
+- Developers: Implement, test, and maintain features.
+- QA/Testing: Validate requirements and acceptance criteria.
+- Stakeholders: Provide input, feedback, and approvals.
+
+---
+
+## Navigate the Process Documents
+
+All key workflow documents and guidelines are stored in this folder. Use these links to access detailed steps for each phase of your project:
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](octoacme-roles-and-personas.md)
+
+---
+
+This README is your entry point for onboarding, discovering best practices, and navigating process documentation for all OctoAcme projects. Refer here for standards, templates, and step-by-step guidance, and help keep these docs up to date for the whole team!


### PR DESCRIPTION
Adds a README landing page to docs/ with a project management process overview, purpose, principles, roles, lifecycle, and navigation links to all key process documents.

Closes #2